### PR TITLE
Modifying Resque version for dependency

### DIFF
--- a/lib/nagios_check_resque/version.rb
+++ b/lib/nagios_check_resque/version.rb
@@ -1,3 +1,3 @@
 module NagiosCheckResque
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/nagios_check_resque.gemspec
+++ b/nagios_check_resque.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'nagios_check', '~> 0.4.0'
-  spec.add_dependency 'resque', '~> 1.25'
+  spec.add_dependency 'resque', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Being able to run the executables with version of Resque above 2.0